### PR TITLE
FIX: Upgraded django version req to meet security flag.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.2.13
+Django==4.0.6
 asgiref==3.4.1
 autopep8==1.6.0
 dj-database-url==0.5.0


### PR DESCRIPTION
I received a notification from github's security bot, about that version of django. I have upgraded and tested with django 4.0.6, all seems to work fine.